### PR TITLE
handle conventional shaders

### DIFF
--- a/src/Budford/Control/FileManager.cs
+++ b/src/Budford/Control/FileManager.cs
@@ -136,8 +136,16 @@ namespace Budford.Control
 
         private static void CheckShouldImport(string fileName, string budfordFolder, out bool copy, out string destination)
         {
+            string suffix = "";
+
+            if (fileName.Contains("_j"))
+            {
+                suffix = "_j";
+            }
+
             copy = false;
-            destination = Path.Combine(budfordFolder, "post_180.bin");
+            destination = Path.Combine(budfordFolder, "post_180" + suffix + ".bin");
+            
             if (!File.Exists(destination))
             {
                 copy = true;

--- a/src/Budford/Control/SpecialFolders.cs
+++ b/src/Budford/Control/SpecialFolders.cs
@@ -103,7 +103,14 @@ namespace Budford.Control
         /// <returns></returns>
         internal static string ShaderCacheCemu(InstalledVersion version, GameInformation game)
         {
-            return Path.Combine(ShaderCacheFolderCemu(version),  game.SaveDir + ".bin");
+            string suffix = "";
+
+            if (game.GameSetting.UseSeperableShaders == 0)
+            {
+                suffix = "_j";
+            }
+
+            return Path.Combine(ShaderCacheFolderCemu(version),  game.SaveDir + suffix + ".bin");
         }
 
         /// <summary>
@@ -114,7 +121,14 @@ namespace Budford.Control
         /// <returns></returns>
         internal static string ShaderCacheBudford(Model.Model model, GameInformation game)
         {
-            return Path.Combine(model.Settings.SavesFolder, "Budford", game.SaveDir, "post_180.bin");
+            string suffix = "";
+
+            if (game.GameSetting.UseSeperableShaders == 0)
+            {
+                suffix = "_j";
+            }
+
+            return Path.Combine(model.Settings.SavesFolder, "Budford", game.SaveDir, "post_180" + suffix + ".bin");
         }
 
         #endregion

--- a/src/Budford/Model/ViewShaderCache.cs
+++ b/src/Budford/Model/ViewShaderCache.cs
@@ -109,18 +109,19 @@ namespace Budford.Model
         /// <param name="game"></param>
         private void UpdateShaderCache(KeyValuePair<string, GameInformation> game)
         {
-            FileInfo transferableShader = new FileInfo(Path.Combine(iv1.Folder, "shaderCache", "transferable", game.Value.SaveDir + ".bin"));
-            FileInfo precompiledShader = new FileInfo(Path.Combine(iv1.Folder, "shaderCache", "precompiled", game.Value.SaveDir + ".bin"));
 
-            if (!File.Exists(precompiledShader.FullName))
+            FileInfo transferableSeperableShader = new FileInfo(Path.Combine(iv1.Folder, "shaderCache", "transferable", game.Value.SaveDir + ".bin"));
+            FileInfo precompiledSeperableShader = new FileInfo(Path.Combine(iv1.Folder, "shaderCache", "precompiled", game.Value.SaveDir + ".bin"));
+
+            FileInfo transferableConventionalShader = new FileInfo(Path.Combine(iv1.Folder, "shaderCache", "transferable", game.Value.SaveDir + "_j.bin"));
+            FileInfo precompiledConventionalShader = new FileInfo(Path.Combine(iv1.Folder, "shaderCache", "precompiled", game.Value.SaveDir + "_j.bin"));
+
+            if ((!File.Exists(precompiledSeperableShader.FullName) && File.Exists(transferableSeperableShader.FullName)) || (!File.Exists(precompiledConventionalShader.FullName) && File.Exists(transferableConventionalShader.FullName)))
             {
-                if (File.Exists(transferableShader.FullName))
+                if (transferableSeperableShader.Length > 1000000 || transferableConventionalShader.Length > 1000000)
                 {
-                    if (transferableShader.Length > 1000000)
-                    {
-                        model.CurrentId = game.Key;
-                        mainForm.Launcher.LaunchCemu(mainForm, model, game.Value, true);
-                    }
+                    model.CurrentId = game.Key;
+                    mainForm.Launcher.LaunchCemu(mainForm, model, game.Value, true);
                 }
             }
         }

--- a/src/Budford/Tools/CopyShaderCache.cs
+++ b/src/Budford/Tools/CopyShaderCache.cs
@@ -30,6 +30,14 @@ namespace Budford.Tools
                         {
                             CopyFile(folder, saveFolder, src, dest);
                         }
+
+                        src = Path.Combine(latest.Folder, "shaderCache", "transferable", game.Value.SaveDir + "_j.bin");
+                        dest = Path.Combine(saveFolder, folder, "post_180_j.bin");
+
+                        if (File.Exists(src))
+                        {
+                            CopyFile(folder, saveFolder, src, dest);
+                        }
                     }
                 }
             }


### PR DESCRIPTION
CEMU conventional shaders are utilized when UseSeperableShaders is disabled.
CEMU conventional shaders are generated with an `_j` suffix.
Bedford currently ignores these shaders in every case.

This PR probably doesn't cover every feature as I'm still very unfamiliar with Bedford and is not actually intended for you to merge.  These are just the changes I made so that the bits of functionality I've used so far will work for the cases where I'm using conventional shaders.

I thought that it might be more useful for you to see the bits and bobs I ran into so far rather than just opening an issue.