### PR TITLE
fix shadercache folder path construction

### DIFF
--- a/src/Budford/Control/Launcher.cs
+++ b/src/Budford/Control/Launcher.cs
@@ -941,12 +941,13 @@ namespace Budford.Control
         {
             if (model.Settings.DisableShaderCache)
             {
-                DirectoryInfo di1 = new DirectoryInfo(Path.Combine(SpecialFolders.ShaderCacheFolderCemu(version), "transferable"));
+                DirectoryInfo di1 = new DirectoryInfo(Path.Combine(SpecialFolders.ShaderCacheFolderCemu(version), "..", "transferable"));
                 foreach (FileInfo file in di1.GetFiles())
                 {
                     FileManager.SafeDelete(file.FullName);
                 }
-                DirectoryInfo di2 = new DirectoryInfo(Path.Combine(SpecialFolders.ShaderCacheFolderCemu(version), "shaderCache", "precompiled"));
+
+                DirectoryInfo di2 = new DirectoryInfo(Path.Combine(SpecialFolders.ShaderCacheFolderCemu(version), "..", "precompiled"));
                 foreach (FileInfo file in di2.GetFiles())
                 {
                     FileManager.SafeDelete(file.FullName);


### PR DESCRIPTION
`Launcher#DeleteShaderCaceIfRequired` constructs two folder paths based off of `SpecialFolders#ShaderFolderCemu` by appending "transferable" and "precompiled" to it's output.

`SpecialFolers#ShaderFolderCemu` is already attaching "transferable" in this case which causes the folder paths to be `%CEMUFOLDER%\shaderCache\transferabe\transferable` and `%CEMUFOLDER%\shaderCache\transferable\precompiled` respectively...

This results in an exception and failure to load the game when it happens.

This change just throws a ".." into the mix so that you wind up with a valid path resolving the issue for me.